### PR TITLE
Add default for `options` parameter

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -42,7 +42,7 @@ function getWelcomeMessage() {
 				</p>
 			</body>
 		</html>
-	`
+	`;
 }
 
 export function withUiHook(handler: Handler) {
@@ -71,8 +71,20 @@ export function withUiHook(handler: Handler) {
 
 		try {
 			const payload = (await getJsonBody(req)) as UiHookPayload;
-			const { token, teamId, slug, integrationId, configurationId} = payload;
-			const zeitClient = new ZeitClient({ token, teamId, slug, integrationId, configurationId });
+			const {
+				token,
+				teamId,
+				slug,
+				integrationId,
+				configurationId
+			} = payload;
+			const zeitClient = new ZeitClient({
+				token,
+				teamId,
+				slug,
+				integrationId,
+				configurationId
+			});
 			const output = await handler({ payload, zeitClient });
 			if (output.isAST === true) {
 				const renderedAST = renderAST(output);

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,14 +11,25 @@ export interface UiHookPayload {
 	clientState: any;
 	installationUrl: string;
 	projectId?: string | null;
-	query: {[key: string]: string | number | string[]};
+	query: { [key: string]: string | number | string[] };
 	slug: string;
 	integrationId: string;
 	configurationId: string;
 	teamId: string | null;
 	token: string;
-	user: { id: string, username: string, email: string, name: string, profiles: any[], },
-	team?: { id: string, slug: string, name: string, description: string, } | null,
+	user: {
+		id: string;
+		username: string;
+		email: string;
+		name: string;
+		profiles: any[];
+	};
+	team?: {
+		id: string;
+		slug: string;
+		name: string;
+		description: string;
+	} | null;
 }
 
 export interface FetchOptions extends RequestInit {

--- a/src/zeit-client.ts
+++ b/src/zeit-client.ts
@@ -17,7 +17,7 @@ export default class ZeitClient {
 		this.options = options;
 	}
 
-	fetch(path: string, options = {}: FetchOptions) {
+	fetch(path: string, options: FetchOptions = {}) {
 		let apiPath = `https://zeit.co/api${path}`;
 
 		if (this.options.teamId) {

--- a/src/zeit-client.ts
+++ b/src/zeit-client.ts
@@ -17,7 +17,7 @@ export default class ZeitClient {
 		this.options = options;
 	}
 
-	fetch(path: string, options: FetchOptions) {
+	fetch(path: string, options = {}: FetchOptions) {
 		let apiPath = `https://zeit.co/api${path}`;
 
 		if (this.options.teamId) {


### PR DESCRIPTION
This does not work:
```js
await zeitClient.fetch(`/user`)
```

This PR aims at fixing it.